### PR TITLE
add include <stdexcept>

### DIFF
--- a/src/util/AsagiReader.cpp
+++ b/src/util/AsagiReader.cpp
@@ -1,4 +1,5 @@
 #include "easi/util/AsagiReader.h"
+#include <stdexcept>
 
 asagi::Grid* easi::AsagiReader::open(char const* file, char const* varname) {
   asagi::Grid* grid = asagi::Grid::createArray();


### PR DESCRIPTION
When compiling easi for ExaHyPE, there is an error related to std::runtime_error. 
I fixed it by including <stdexcept>