### PR TITLE
Fix cmake installation and add semantic versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,16 +12,31 @@ enable_language(CXX)
 enable_language(Fortran)
 
 option(ASAGI "Enable support for ASAGI" ON)
-option(IMPALAJIT "Use ImpalaJIT" ON)
-option(IMPALAJIT_LLVM "Use llvm version of ImpalaJIT" OFF)
 
-### external packages ###
+option(IMPALAJIT "Use ImpalaJIT" ON)
+set(IMPALAJIT_BACKEND original CACHE STRING "Which backend to use")
+set(IMPALAJIT_BACKEND_OPTIONS original llvm)
+set_property(CACHE IMPALAJIT_BACKEND PROPERTY STRINGS ${IMPALAJIT_BACKEND_OPTIONS})
+
+function(check_parameter parameter_name value options)
+
+    list(FIND options ${value} INDEX)
+
+    set(WRONG_PARAMETER -1)
+    if (${INDEX} EQUAL ${WRONG_PARAMETER})
+        message(FATAL_ERROR "${parameter_name} is wrong. Specified \"${value}\". Allowed: ${options}")
+    endif()
+
+endfunction()
+check_parameter("IMPALAJIT_BACKEND" "${IMPALAJIT_BACKEND}" "${IMPALAJIT_BACKEND_OPTIONS}")
+
+    ### external packages ###
 
 find_package(yaml-cpp 0.6 REQUIRED)
 find_package(OpenMP)
 
 if(IMPALAJIT)
-    if (IMPALAJIT_LLVM)
+    if (IMPALAJIT_BACKEND STREQUAL llvm)
         find_package(ImpalaJIT-LLVM 1.0 REQUIRED)
     else()
         find_package (impalajit REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 if(ASAGI)
     find_package (PkgConfig REQUIRED)
     find_package (HDF5 REQUIRED COMPONENTS C HL)
-    #pkg_check_modules (NETCDF REQUIRED IMPORTED_TARGET netcdf)
+    pkg_check_modules (NETCDF REQUIRED IMPORTED_TARGET netcdf)
     pkg_check_modules (ASAGI REQUIRED IMPORTED_TARGET asagi)
 endif()
 
@@ -73,10 +73,10 @@ endif()
 if(ASAGI)
     find_package(MPI REQUIRED)
     target_link_libraries(easi
-        PRIVATE
+        PUBLIC
             ${HDF5_C_HL_LIBRARIES} ${HDF5_C_LIBRARIES}
             PkgConfig::ASAGI
-            #PkgConfig::NETCDF
+            PkgConfig::NETCDF
     )
     target_link_libraries(easi
             PRIVATE
@@ -138,43 +138,46 @@ install(
 ### easicube ###
 
 if(ASAGI)
-    #add_executable (easicube tools/easicube.cpp)
-    #target_link_libraries(easicube PRIVATE easi)
-    #set_target_properties (easicube PROPERTIES
-        #INSTALL_RPATH_USE_LINK_PATH TRUE
-    #)
-    #install (TARGETS easicube)
+    add_executable (easicube tools/easicube.cpp)
+    target_link_libraries(easicube PRIVATE easi)
+    set_target_properties (easicube PROPERTIES
+        INSTALL_RPATH_USE_LINK_PATH TRUE
+    )
+    install (TARGETS easicube)
 endif()
 
 
 ### tests ###
+enable_testing()
+add_library(easitest
+    tests/easitest.cpp
+    tests/special.f90
+)
+target_link_libraries(easitest PUBLIC easi)
 
-#enable_testing()
-#add_library(easitest
-    #tests/easitest.cpp
-    #tests/special.f90
-#)
-#target_link_libraries(easitest PUBLIC easi)
+function(easi_add_test name)
+    add_executable(${name} tests/${name}.cpp)
+    target_link_libraries(${name} PRIVATE easitest)
+    string(TOUPPER ${name} NAME_UP)
+    add_test(${NAME_UP}_TEST ${name} ${CMAKE_CURRENT_SOURCE_DIR}/examples/${name}.yaml)
+endfunction(easi_add_test)
 
-#function(easi_add_test name)
-    #add_executable(${name} tests/${name}.cpp)
-    #target_link_libraries(${name} PRIVATE easitest)
-    #string(TOUPPER ${name} NAME_UP)
-    #add_test(${NAME_UP}_TEST ${name} ${CMAKE_CURRENT_SOURCE_DIR}/examples/${name}.yaml)
-#endfunction(easi_add_test)
+easi_add_test(0_constant)
+easi_add_test(1_groups)
+easi_add_test(3_layered_linear)
+easi_add_test(33_layered_constant)
 
-#easi_add_test(0_constant)
-#easi_add_test(1_groups)
-#easi_add_test(2_prem)
-#easi_add_test(3_layered_linear)
-#easi_add_test(5_function)
-#easi_add_test(26_function)
-#easi_add_test(33_layered_constant)
-#if(ASAGI)
-    #easi_add_test(101_asagi)
-    #easi_add_test(101_asagi_nearest)
-#endif ()
-#easi_add_test(f_16_scec)
-#easi_add_test(f_120_sumatra)
-#easi_add_test(supplied_parameters)
-#
+if(IMPALA)
+    easi_add_test(2_prem)
+    easi_add_test(5_function)
+    easi_add_test(26_function)
+    easi_add_test(f_16_scec)
+    easi_add_test(f_120_sumatra)
+    easi_add_test(supplied_parameters)
+endif()
+
+if(ASAGI)
+    easi_add_test(101_asagi)
+    easi_add_test(101_asagi_nearest)
+endif ()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,13 +71,18 @@ if(${OpenMP_CXX_FOUND})
     target_link_libraries(easi PRIVATE OpenMP::OpenMP_CXX)
 endif()
 if(ASAGI)
+    find_package(MPI REQUIRED)
     target_link_libraries(easi
         PRIVATE
             ${HDF5_C_HL_LIBRARIES} ${HDF5_C_LIBRARIES}
             PkgConfig::ASAGI
             PkgConfig::NETCDF
     )
-    target_compile_definitions(easi PUBLIC -DUSE_ASAGI)
+    target_link_libraries(easi
+            PUBLIC
+            MPI::MPI_CXX
+    )
+    target_compile_definitions(easi PRIVATE -DUSE_ASAGI)
 endif()
 if(IMPALAJIT)
     target_link_libraries(easi PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 project(easi)
 cmake_minimum_required(VERSION 3.13)
+set(EASI_VERSION_MAJOR 1)
+set(EASI_VERSION_MINOR 0)
+set(EASI_VERSION_PATCH 0)
+
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -136,8 +140,16 @@ configure_package_config_file(
     "${CMAKE_CURRENT_BINARY_DIR}/easiConfig.cmake"
     INSTALL_DESTINATION ${CONFIG_DESTINATION}
 )
+
+write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/easiConfigVersion.cmake"
+        VERSION ${EASI_VERSION_MAJOR}.${EASI_VERSION_MINOR}.${EASI_VERSION_PATCH}
+        COMPATIBILITY SameMajorVersion
+)
 install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/easiConfig.cmake"
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/easiConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/easiConfigVersion.cmake"
     DESTINATION ${CONFIG_DESTINATION}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 if(ASAGI)
     find_package (PkgConfig REQUIRED)
     find_package (HDF5 REQUIRED COMPONENTS C HL)
-    pkg_check_modules (NETCDF REQUIRED IMPORTED_TARGET netcdf)
+    #pkg_check_modules (NETCDF REQUIRED IMPORTED_TARGET netcdf)
     pkg_check_modules (ASAGI REQUIRED IMPORTED_TARGET asagi)
 endif()
 
@@ -76,19 +76,19 @@ if(ASAGI)
         PRIVATE
             ${HDF5_C_HL_LIBRARIES} ${HDF5_C_LIBRARIES}
             PkgConfig::ASAGI
-            PkgConfig::NETCDF
+            #PkgConfig::NETCDF
     )
     target_link_libraries(easi
-            PUBLIC
+            PRIVATE
             MPI::MPI_CXX
     )
-    target_compile_definitions(easi PRIVATE -DUSE_ASAGI)
+    target_compile_definitions(easi PRIVATE -DEASI_USE_ASAGI)
 endif()
 if(IMPALAJIT)
     target_link_libraries(easi PRIVATE
             impalajit::impalajit
     )
-    target_compile_definitions(easi PUBLIC -DUSE_IMPALAJIT)
+    target_compile_definitions(easi PRIVATE -DEASI_USE_IMPALAJIT)
 endif()
 
 target_include_directories(easi
@@ -100,6 +100,7 @@ target_include_directories(easi
 )
 
 # installation
+set_target_properties(easi PROPERTIES INSTALL_RPATH_USE_LINK_PATH True)
 
 set(CONFIG_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/easi)
 
@@ -114,8 +115,17 @@ install(EXPORT easi-targets
     DESTINATION ${CONFIG_DESTINATION}
 )
 
+
+# Replace variables in script
+# Note: Configure file also replaces @PACKAGE_INIT@, we don't want that
+set(PACKAGE_INIT_OLD "${PACKAGE_INIT}")
+set(PACKAGE_INIT "@PACKAGE_INIT@")
+configure_file(cmake/easiConfig.cmake.in cmake/easiConfig.cmake @ONLY)
+set(PACKAGE_INIT "${PACKAGE_INIT_OLD}")
+unset(PACKAGE_INIT_OLD)
+
 configure_package_config_file(
-    cmake/easiConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/easiConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/easiConfig.cmake"
     INSTALL_DESTINATION ${CONFIG_DESTINATION}
 )
@@ -128,42 +138,43 @@ install(
 ### easicube ###
 
 if(ASAGI)
-    add_executable (easicube tools/easicube.cpp)
-    target_link_libraries(easicube PRIVATE easi)
-    set_target_properties (easicube PROPERTIES
-        INSTALL_RPATH_USE_LINK_PATH TRUE
-    )
-    install (TARGETS easicube)
+    #add_executable (easicube tools/easicube.cpp)
+    #target_link_libraries(easicube PRIVATE easi)
+    #set_target_properties (easicube PROPERTIES
+        #INSTALL_RPATH_USE_LINK_PATH TRUE
+    #)
+    #install (TARGETS easicube)
 endif()
 
 
 ### tests ###
 
-enable_testing()
-add_library(easitest
-    tests/easitest.cpp
-    tests/special.f90
-)
-target_link_libraries(easitest PUBLIC easi)
+#enable_testing()
+#add_library(easitest
+    #tests/easitest.cpp
+    #tests/special.f90
+#)
+#target_link_libraries(easitest PUBLIC easi)
 
-function(easi_add_test name)
-    add_executable(${name} tests/${name}.cpp)
-    target_link_libraries(${name} PRIVATE easitest)
-    string(TOUPPER ${name} NAME_UP)
-    add_test(${NAME_UP}_TEST ${name} ${CMAKE_CURRENT_SOURCE_DIR}/examples/${name}.yaml)
-endfunction(easi_add_test)
+#function(easi_add_test name)
+    #add_executable(${name} tests/${name}.cpp)
+    #target_link_libraries(${name} PRIVATE easitest)
+    #string(TOUPPER ${name} NAME_UP)
+    #add_test(${NAME_UP}_TEST ${name} ${CMAKE_CURRENT_SOURCE_DIR}/examples/${name}.yaml)
+#endfunction(easi_add_test)
 
-easi_add_test(0_constant)
-easi_add_test(1_groups)
-easi_add_test(2_prem)
-easi_add_test(3_layered_linear)
-easi_add_test(5_function)
-easi_add_test(26_function)
-easi_add_test(33_layered_constant)
-if(ASAGI)
-    easi_add_test(101_asagi)
-    easi_add_test(101_asagi_nearest)
-endif ()
-easi_add_test(f_16_scec)
-easi_add_test(f_120_sumatra)
-easi_add_test(supplied_parameters)
+#easi_add_test(0_constant)
+#easi_add_test(1_groups)
+#easi_add_test(2_prem)
+#easi_add_test(3_layered_linear)
+#easi_add_test(5_function)
+#easi_add_test(26_function)
+#easi_add_test(33_layered_constant)
+#if(ASAGI)
+    #easi_add_test(101_asagi)
+    #easi_add_test(101_asagi_nearest)
+#endif ()
+#easi_add_test(f_16_scec)
+#easi_add_test(f_120_sumatra)
+#easi_add_test(supplied_parameters)
+#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ enable_language(CXX)
 enable_language(Fortran)
 
 option(ASAGI "Enable support for ASAGI" ON)
-option(IMPALAJIT "Use ImpalaJIT" OFF)
+option(IMPALAJIT "Use ImpalaJIT" ON)
 
 ### external packages ###
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ enable_language(Fortran)
 
 option(ASAGI "Enable support for ASAGI" ON)
 option(IMPALAJIT "Use ImpalaJIT" ON)
+option(IMPALAJIT_LLVM "Use llvm version of ImpalaJIT" OFF)
 
 ### external packages ###
 
@@ -16,7 +17,11 @@ find_package(yaml-cpp 0.6 REQUIRED)
 find_package(OpenMP)
 
 if(IMPALAJIT)
-    find_package (impalajit REQUIRED)
+    if (IMPALAJIT_LLVM)
+        find_package(ImpalaJIT-LLVM 1.0 REQUIRED)
+    else()
+        find_package (impalajit REQUIRED)
+    endif()
 endif()
 
 if(ASAGI)
@@ -84,10 +89,12 @@ if(ASAGI)
     )
     target_compile_definitions(easi PRIVATE -DEASI_USE_ASAGI)
 endif()
-if(IMPALAJIT)
-    target_link_libraries(easi PRIVATE
-            impalajit::impalajit
-    )
+if (IMPALAJIT)
+    if (IMPALAJIT_LLVM)
+        target_link_libraries(easi PRIVATE llvm::impalajit)
+    else()
+        target_link_libraries(easi PRIVATE impalajit::impalajit)
+    endif()
     target_compile_definitions(easi PRIVATE -DEASI_USE_IMPALAJIT)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,34 @@
-project (easi)
-cmake_minimum_required (VERSION 3.13)
+project(easi)
+cmake_minimum_required(VERSION 3.13)
 
-include (GNUInstallDirs)
-include (CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
-enable_language (CXX)
-enable_language (Fortran)
+enable_language(CXX)
+enable_language(Fortran)
 
-option (ASAGI "Enable support for ASAGI" ON)
+option(ASAGI "Enable support for ASAGI" ON)
+option(IMPALAJIT "Use ImpalaJIT" OFF)
 
 ### external packages ###
 
-find_package (yaml-cpp REQUIRED)
-find_package (impalajit REQUIRED)
-find_package (OpenMP)
+find_package(yaml-cpp 0.6 REQUIRED)
+find_package(OpenMP)
 
-if (ASAGI)
+if(IMPALAJIT)
+    find_package (impalajit REQUIRED)
+endif()
+
+if(ASAGI)
     find_package (PkgConfig REQUIRED)
     find_package (HDF5 REQUIRED COMPONENTS C HL)
     pkg_check_modules (NETCDF REQUIRED IMPORTED_TARGET netcdf)
     pkg_check_modules (ASAGI REQUIRED IMPORTED_TARGET asagi)
-endif ()
+endif()
 
 ### easi lib ###
 
-set (EASI_SOURCES
+set(EASI_SOURCES
     src/component/AffineMap.cpp
     src/component/AndersonianStress.cpp
     src/component/Composite.cpp
@@ -45,39 +49,44 @@ set (EASI_SOURCES
     src/Query.cpp
     src/YAMLParser.cpp
 )
-if (ASAGI)
-    list (APPEND EASI_SOURCES
+if(ASAGI)
+    list(APPEND EASI_SOURCES
         src/component/ASAGI.cpp
         src/util/AsagiReader.cpp
     )
-endif ()
+endif()
 
-add_library (easi ${EASI_SOURCES})
-target_compile_features (easi PUBLIC cxx_std_14)
+add_library(easi ${EASI_SOURCES})
+target_compile_features(easi PUBLIC cxx_std_14)
 set_target_properties(easi PROPERTIES
     CXX_STANDARD 14
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )
-target_link_libraries (easi
+target_link_libraries(easi
     PUBLIC
         yaml-cpp
-    PRIVATE
-        impalajit::impalajit
 )
-if (${OpenMP_CXX_FOUND})
-    target_link_libraries (easi PRIVATE OpenMP::OpenMP_CXX)
-endif ()
-if (ASAGI)
-    target_link_libraries (easi
+if(${OpenMP_CXX_FOUND})
+    target_link_libraries(easi PRIVATE OpenMP::OpenMP_CXX)
+endif()
+if(ASAGI)
+    target_link_libraries(easi
         PRIVATE
             ${HDF5_C_HL_LIBRARIES} ${HDF5_C_LIBRARIES}
             PkgConfig::ASAGI
             PkgConfig::NETCDF
     )
-    target_compile_definitions (easi PUBLIC -DUSE_ASAGI)
-endif ()
-target_include_directories (easi
+    target_compile_definitions(easi PUBLIC -DUSE_ASAGI)
+endif()
+if(IMPALAJIT)
+    target_link_libraries(easi PRIVATE
+            impalajit::impalajit
+    )
+    target_compile_definitions(easi PUBLIC -DUSE_IMPALAJIT)
+endif()
+
+target_include_directories(easi
     PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -89,23 +98,23 @@ target_include_directories (easi
 
 set(CONFIG_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/easi)
 
-install (TARGETS easi EXPORT easi-targets
+install(TARGETS easi EXPORT easi-targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install (DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install (EXPORT easi-targets
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(EXPORT easi-targets
     FILE easiTargets.cmake
     NAMESPACE easi::
     DESTINATION ${CONFIG_DESTINATION}
 )
 
-configure_package_config_file (
+configure_package_config_file(
     cmake/easiConfig.cmake.in
     "${CMAKE_CURRENT_BINARY_DIR}/easiConfig.cmake"
     INSTALL_DESTINATION ${CONFIG_DESTINATION}
 )
-install (
+install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/easiConfig.cmake"
     DESTINATION ${CONFIG_DESTINATION}
 )
@@ -113,43 +122,43 @@ install (
 
 ### easicube ###
 
-if (ASAGI)
+if(ASAGI)
     add_executable (easicube tools/easicube.cpp)
     target_link_libraries(easicube PRIVATE easi)
     set_target_properties (easicube PROPERTIES
         INSTALL_RPATH_USE_LINK_PATH TRUE
     )
     install (TARGETS easicube)
-endif ()
+endif()
 
 
 ### tests ###
 
-enable_testing ()
-add_library (easitest
+enable_testing()
+add_library(easitest
     tests/easitest.cpp
     tests/special.f90
 )
 target_link_libraries(easitest PUBLIC easi)
 
-function (easi_add_test name)
-    add_executable (${name} tests/${name}.cpp)
-    target_link_libraries (${name} PRIVATE easitest)
-    string (TOUPPER ${name} NAME_UP)
-    add_test (${NAME_UP}_TEST ${name} ${CMAKE_CURRENT_SOURCE_DIR}/examples/${name}.yaml)
-endfunction (easi_add_test)
+function(easi_add_test name)
+    add_executable(${name} tests/${name}.cpp)
+    target_link_libraries(${name} PRIVATE easitest)
+    string(TOUPPER ${name} NAME_UP)
+    add_test(${NAME_UP}_TEST ${name} ${CMAKE_CURRENT_SOURCE_DIR}/examples/${name}.yaml)
+endfunction(easi_add_test)
 
-easi_add_test (0_constant)
-easi_add_test (1_groups)
-easi_add_test (2_prem)
-easi_add_test (3_layered_linear)
-easi_add_test (5_function)
-easi_add_test (26_function)
-easi_add_test (33_layered_constant)
-if (ASAGI)
-    easi_add_test (101_asagi)
-    easi_add_test (101_asagi_nearest)
+easi_add_test(0_constant)
+easi_add_test(1_groups)
+easi_add_test(2_prem)
+easi_add_test(3_layered_linear)
+easi_add_test(5_function)
+easi_add_test(26_function)
+easi_add_test(33_layered_constant)
+if(ASAGI)
+    easi_add_test(101_asagi)
+    easi_add_test(101_asagi_nearest)
 endif ()
-easi_add_test (f_16_scec)
-easi_add_test (f_120_sumatra)
-easi_add_test (supplied_parameters)
+easi_add_test(f_16_scec)
+easi_add_test(f_120_sumatra)
+easi_add_test(supplied_parameters)

--- a/cmake/easiConfig.cmake.in
+++ b/cmake/easiConfig.cmake.in
@@ -1,5 +1,5 @@
 @PACKAGE_INIT@
-set(EASI_IMPALAJITLLVM @IMPALAJIT_LLVM@)
+set(EASI_IMPALAJIT_BACKEND @IMPALAJIT_BACKEND@)
 set(EASI_IMPALAJIT @IMPALAJIT@)
 set(EASI_ASAGI @ASAGI@)
 
@@ -9,10 +9,10 @@ find_dependency(OpenMP)
 find_dependency(yaml-cpp 0.6 REQUIRED)
 
 if (EASI_IMPALAJIT)
-    if (EASI_IMPALAJIT_LLVM)
-        find_dependency(ImpalaJIT-LLVM 1.0 REQUIRED)
+    if (EASI_IMPALAJIT_BACKEND STREQUAL llvm)
+        find_package(ImpalaJIT-LLVM 1.0 REQUIRED)
     else()
-        find_dependency(impalajit REQUIRED)
+        find_package (impalajit REQUIRED)
     endif()
 endif()
 

--- a/cmake/easiConfig.cmake.in
+++ b/cmake/easiConfig.cmake.in
@@ -1,8 +1,21 @@
+@PACKAGE_INIT@
+set(EASI_IMPALAJIT @IMPALAJIT@)
+set(EASI_ASAGI @ASAGI@)
+
 include (CMakeFindDependencyMacro)
 
-find_dependency (yaml-cpp REQUIRED)
-find_dependency (impalajit REQUIRED)
 find_dependency (OpenMP)
+find_dependency(yaml-cpp 0.6 REQUIRED)
+
+if(EASI_IMPALAJIT)
+    find_dependency (impalajit REQUIRED)
+endif()
+
+if(EASI_ASAGI)
+    find_dependency(PkgConfig)
+    pkg_check_modules(ASAGI REQUIRED IMPORTED_TARGET asagi)
+    pkg_check_modules(NETCDF REQUIRED IMPORTED_TARGET netcdf)
+endif()
 
 if (NOT TARGET easi::easi)
     include ("${CMAKE_CURRENT_LIST_DIR}/easiTargets.cmake")

--- a/cmake/easiConfig.cmake.in
+++ b/cmake/easiConfig.cmake.in
@@ -1,17 +1,22 @@
 @PACKAGE_INIT@
+set(EASI_IMPALAJITLLVM @IMPALAJIT_LLVM@)
 set(EASI_IMPALAJIT @IMPALAJIT@)
 set(EASI_ASAGI @ASAGI@)
 
-include (CMakeFindDependencyMacro)
+include(CMakeFindDependencyMacro)
 
-find_dependency (OpenMP)
+find_dependency(OpenMP)
 find_dependency(yaml-cpp 0.6 REQUIRED)
 
-if(EASI_IMPALAJIT)
-    find_dependency (impalajit REQUIRED)
+if (EASI_IMPALAJIT)
+    if (EASI_IMPALAJIT_LLVM)
+        find_dependency(ImpalaJIT-LLVM 1.0 REQUIRED)
+    else()
+        find_dependency(impalajit REQUIRED)
+    endif()
 endif()
 
-if(EASI_ASAGI)
+if (EASI_ASAGI)
     find_dependency(PkgConfig)
     pkg_check_modules(ASAGI REQUIRED IMPORTED_TARGET asagi)
     pkg_check_modules(NETCDF REQUIRED IMPORTED_TARGET netcdf)

--- a/include/easi/component/FunctionMap.h
+++ b/include/easi/component/FunctionMap.h
@@ -1,7 +1,7 @@
 #ifndef EASI_COMPONENT_FUNCTIONMAP_H_
 #define EASI_COMPONENT_FUNCTIONMAP_H_
 
-#ifdef USE_IMPALAJIT
+#ifdef EASI_USE_IMPALAJIT
 #include "easi/component/Map.h"
 #include "easi/util/FunctionWrapper.h"
 #include "easi/util/Matrix.h"
@@ -32,6 +32,6 @@ private:
 
 } // namespace easi
 
-#endif // USE_IMPALAJIT
+#endif // EASI_USE_IMPALAJIT
 
 #endif

--- a/include/easi/component/FunctionMap.h
+++ b/include/easi/component/FunctionMap.h
@@ -1,6 +1,7 @@
 #ifndef EASI_COMPONENT_FUNCTIONMAP_H_
 #define EASI_COMPONENT_FUNCTIONMAP_H_
 
+#ifdef USE_IMPALAJIT
 #include "easi/component/Map.h"
 #include "easi/util/FunctionWrapper.h"
 #include "easi/util/Matrix.h"
@@ -30,5 +31,7 @@ private:
 };
 
 } // namespace easi
+
+#endif // USE_IMPALAJIT
 
 #endif

--- a/include/easi/parser/YAMLComponentParsers.h
+++ b/include/easi/parser/YAMLComponentParsers.h
@@ -53,8 +53,10 @@ void parse_ConstantMap(ConstantMap* component, YAML::Node const& node,
                        std::set<std::string> const& in, YAMLAbstractParser* parser);
 void parse_AffineMap(AffineMap* component, YAML::Node const& node, std::set<std::string> const& in,
                      YAMLAbstractParser* parser);
+#ifdef USE_IMPALAJIT
 void parse_FunctionMap(FunctionMap* component, YAML::Node const& node,
                        std::set<std::string> const& in, YAMLAbstractParser* parser);
+#endif
 void parse_PolynomialMap(PolynomialMap* component, YAML::Node const& node,
                          std::set<std::string> const& in, YAMLAbstractParser* parser);
 void parse_SCECFile(SCECFile* component, YAML::Node const& node, std::set<std::string> const& in,

--- a/include/easi/parser/YAMLComponentParsers.h
+++ b/include/easi/parser/YAMLComponentParsers.h
@@ -18,7 +18,7 @@
 #include "easi/parser/YAMLAbstractParser.h"
 #include "easi/parser/YAMLHelpers.h"
 
-#ifdef USE_ASAGI
+#ifdef EASI_USE_ASAGI
 #include "easi/component/ASAGI.h"
 #endif
 
@@ -53,7 +53,7 @@ void parse_ConstantMap(ConstantMap* component, YAML::Node const& node,
                        std::set<std::string> const& in, YAMLAbstractParser* parser);
 void parse_AffineMap(AffineMap* component, YAML::Node const& node, std::set<std::string> const& in,
                      YAMLAbstractParser* parser);
-#ifdef USE_IMPALAJIT
+#ifdef EASI_USE_IMPALAJIT
 void parse_FunctionMap(FunctionMap* component, YAML::Node const& node,
                        std::set<std::string> const& in, YAMLAbstractParser* parser);
 #endif
@@ -61,7 +61,7 @@ void parse_PolynomialMap(PolynomialMap* component, YAML::Node const& node,
                          std::set<std::string> const& in, YAMLAbstractParser* parser);
 void parse_SCECFile(SCECFile* component, YAML::Node const& node, std::set<std::string> const& in,
                     YAMLAbstractParser* parser);
-#ifdef USE_ASAGI
+#ifdef EASI_USE_ASAGI
 void parse_ASAGI(ASAGI* component, YAML::Node const& node, std::set<std::string> const& in,
                  YAMLAbstractParser* parser);
 #endif

--- a/include/easi/util/FunctionWrapper.h
+++ b/include/easi/util/FunctionWrapper.h
@@ -1,7 +1,7 @@
 #ifndef EASI_UTIL_FUNCTIONWRAPPER_H_
 #define EASI_UTIL_FUNCTIONWRAPPER_H_
 
-#ifdef USE_IMPALAJIT
+#ifdef EASI_USE_IMPALAJIT
 #include <impalajit/types.hh>
 
 namespace easi {
@@ -12,6 +12,6 @@ typedef double (*function_wrapper_t)(dasm_gen_func, Matrix<double> const&, unsig
 function_wrapper_t getFunctionWrapper(unsigned dimDomain);
 
 } // namespace easi
-#endif // USE_IMPALAJIT
+#endif // EASI_USE_IMPALAJIT
 
 #endif

--- a/include/easi/util/FunctionWrapper.h
+++ b/include/easi/util/FunctionWrapper.h
@@ -1,6 +1,7 @@
 #ifndef EASI_UTIL_FUNCTIONWRAPPER_H_
 #define EASI_UTIL_FUNCTIONWRAPPER_H_
 
+#ifdef USE_IMPALAJIT
 #include <impalajit/types.hh>
 
 namespace easi {
@@ -11,5 +12,6 @@ typedef double (*function_wrapper_t)(dasm_gen_func, Matrix<double> const&, unsig
 function_wrapper_t getFunctionWrapper(unsigned dimDomain);
 
 } // namespace easi
+#endif // USE_IMPALAJIT
 
 #endif

--- a/src/YAMLParser.cpp
+++ b/src/YAMLParser.cpp
@@ -31,7 +31,9 @@ YAMLParser::YAMLParser(unsigned dimDomain, AsagiReader* externalAsagiReader, cha
     registerType("!AxisAlignedCuboidalDomainFilter", parse_AxisAlignedCuboidalDomainFilter);
     registerType("!SphericalDomainFilter", parse_SphericalDomainFilter);
     registerType("!AffineMap", parse_AffineMap);
+#ifdef USE_IMPALAJIT
     registerType("!FunctionMap", parse_FunctionMap);
+#endif
     registerType("!SCECFile", parse_SCECFile);
 #ifdef USE_ASAGI
     registerType("!ASAGI", parse_ASAGI);

--- a/src/YAMLParser.cpp
+++ b/src/YAMLParser.cpp
@@ -5,7 +5,7 @@
 #include "easi/component/Special.h"
 #include "easi/parser/YAMLComponentParsers.h"
 
-#ifdef USE_ASAGI
+#ifdef EASI_USE_ASAGI
 #include "easi/util/AsagiReader.h"
 #else
 namespace easi {
@@ -31,11 +31,11 @@ YAMLParser::YAMLParser(unsigned dimDomain, AsagiReader* externalAsagiReader, cha
     registerType("!AxisAlignedCuboidalDomainFilter", parse_AxisAlignedCuboidalDomainFilter);
     registerType("!SphericalDomainFilter", parse_SphericalDomainFilter);
     registerType("!AffineMap", parse_AffineMap);
-#ifdef USE_IMPALAJIT
+#ifdef EASI_USE_IMPALAJIT
     registerType("!FunctionMap", parse_FunctionMap);
 #endif
     registerType("!SCECFile", parse_SCECFile);
-#ifdef USE_ASAGI
+#ifdef EASI_USE_ASAGI
     registerType("!ASAGI", parse_ASAGI);
 #endif
     registerType("!LayeredModel", create_LayeredModel);

--- a/src/component/FunctionMap.cpp
+++ b/src/component/FunctionMap.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_IMPALAJIT
+#ifdef EASI_USE_IMPALAJIT
 #include "easi/component/FunctionMap.h"
 
 #include <impalajit.hh>
@@ -64,4 +64,4 @@ void FunctionMap::setMap(std::set<std::string> const& in, OutMap const& function
 }
 
 } // namespace easi
-#endif // USE_IMPALAJIT
+#endif // EASI_USE_IMPALAJIT

--- a/src/component/FunctionMap.cpp
+++ b/src/component/FunctionMap.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_IMPALAJIT
 #include "easi/component/FunctionMap.h"
 
 #include <impalajit.hh>
@@ -63,3 +64,4 @@ void FunctionMap::setMap(std::set<std::string> const& in, OutMap const& function
 }
 
 } // namespace easi
+#endif // USE_IMPALAJIT

--- a/src/parser/YAMLComponentParsers.cpp
+++ b/src/parser/YAMLComponentParsers.cpp
@@ -1,6 +1,6 @@
 #include "easi/parser/YAMLComponentParsers.h"
 
-#ifdef USE_ASAGI
+#ifdef EASI_USE_ASAGI
 #include "easi/util/AsagiReader.h"
 #endif
 
@@ -133,7 +133,7 @@ void parse_AffineMap(AffineMap* component, YAML::Node const& node, std::set<std:
     parse_Map(component, node, in, parser);
 }
 
-#ifdef USE_IMPALAJIT
+#ifdef EASI_USE_IMPALAJIT
 void parse_FunctionMap(FunctionMap* component, YAML::Node const& node,
                        std::set<std::string> const& in, YAMLAbstractParser* parser) {
     checkType(node, "map", {YAML::NodeType::Map});
@@ -176,7 +176,7 @@ void parse_SCECFile(SCECFile* component, YAML::Node const& node, std::set<std::s
     parse_Grid<SCECFile>(component, node, in, parser);
 }
 
-#ifdef USE_ASAGI
+#ifdef EASI_USE_ASAGI
 void parse_ASAGI(ASAGI* component, YAML::Node const& node, std::set<std::string> const& in,
                  YAMLAbstractParser* parser) {
     checkType(node, "file", {YAML::NodeType::Scalar});

--- a/src/parser/YAMLComponentParsers.cpp
+++ b/src/parser/YAMLComponentParsers.cpp
@@ -133,6 +133,7 @@ void parse_AffineMap(AffineMap* component, YAML::Node const& node, std::set<std:
     parse_Map(component, node, in, parser);
 }
 
+#ifdef USE_IMPALAJIT
 void parse_FunctionMap(FunctionMap* component, YAML::Node const& node,
                        std::set<std::string> const& in, YAMLAbstractParser* parser) {
     checkType(node, "map", {YAML::NodeType::Map});
@@ -142,6 +143,7 @@ void parse_FunctionMap(FunctionMap* component, YAML::Node const& node,
     component->setMap(in, out);
     parse_Map(component, node, in, parser);
 }
+#endif
 
 void parse_PolynomialMap(PolynomialMap* component, YAML::Node const& node,
                          std::set<std::string> const& in, YAMLAbstractParser* parser) {

--- a/src/util/FunctionWrapper.cpp
+++ b/src/util/FunctionWrapper.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_IMPALAJIT
+#ifdef EASI_USE_IMPALAJIT
 #include "easi/util/FunctionWrapper.h"
 #include "easi/util/Matrix.h"
 

--- a/src/util/FunctionWrapper.cpp
+++ b/src/util/FunctionWrapper.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_IMPALAJIT
 #include "easi/util/FunctionWrapper.h"
 #include "easi/util/Matrix.h"
 
@@ -69,3 +70,5 @@ function_wrapper_t getFunctionWrapper(unsigned dimDomain) {
 }
 
 } // namespace easi
+
+#endif // IMPALA_JIT

--- a/tests/supplied_parameters.cpp
+++ b/tests/supplied_parameters.cpp
@@ -1,4 +1,5 @@
 #include "easi/YAMLParser.h"
+#include <algorithm>
 
 int main(int argc, char** argv) {
     assert(argc == 2);


### PR DESCRIPTION
With these patches, using easi is as easy as writing:
`find_package(easi 1.0.0 REQUIRED)`
This is used in the following SeisSol PR:
https://github.com/SeisSol/SeisSol/pull/454

For this approach to work, we need to introduce version numbers - otherwise we land in dependency hell. This PR follows the semver standard:
https://semver.org/

@ravil-mobile Please try out whether it works with ImpalaJIT-LLVM

