### PR TITLE
Add mpi init and finalize, if built with ASAGI support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ install(
 if(ASAGI)
     add_executable (easicube tools/easicube.cpp)
     target_link_libraries(easicube PRIVATE easi)
+    target_compile_definitions(easicube PRIVATE EASI_USE_ASAGI)
     set_target_properties (easicube PROPERTIES
         INSTALL_RPATH_USE_LINK_PATH TRUE
     )

--- a/tools/easicube.cpp
+++ b/tools/easicube.cpp
@@ -37,7 +37,7 @@ void check_err(int const stat, int const line, char const* file) {
 }
 
 int main(int argc, char** argv) {
-   MPI_Init(NULL, NULL);
+    MPI_Init(&argc, &argv);
     if (argc < 3) {
         std::cerr << "Usage: easicube \"{from: [...], to: [...], N: [...], parameters: [...], "
                      "group: ...}\" <model_file> [<output_basename>]"

--- a/tools/easicube.cpp
+++ b/tools/easicube.cpp
@@ -21,6 +21,13 @@
 #include <unordered_map>
 #include <vector>
 
+#ifdef EASI_USE_ASAGI
+#include "mpi.h"
+#else
+void MPI_Init(int *argc, char ***argv) {};
+void MPI_Finalize() {};
+#endif
+
 void check_err(int const stat, int const line, char const* file) {
     if (stat != NC_NOERR) {
         fprintf(stderr, "line %d of %s: %s\n", line, file, nc_strerror(stat));
@@ -30,6 +37,7 @@ void check_err(int const stat, int const line, char const* file) {
 }
 
 int main(int argc, char** argv) {
+   MPI_Init(NULL, NULL);
     if (argc < 3) {
         std::cerr << "Usage: easicube \"{from: [...], to: [...], N: [...], parameters: [...], "
                      "group: ...}\" <model_file> [<output_basename>]"
@@ -228,5 +236,6 @@ int main(int argc, char** argv) {
         check_err(stat, __LINE__, __FILE__);
     }
 
+    MPI_Finalize();
     return 0;
 }


### PR DESCRIPTION
Fixes the following error:
```
> easicube "{from: [465000, 7196000, -195000], to: [769000, 7480000, 3746], N: [10, 10, 10]}" material.yaml test

*** The MPI_Type_contiguous() function was called before MPI_INIT was invoked.
*** This is disallowed by the MPI standard.
*** Your MPI job will now abort.
```
