### PR TITLE
fix easicube linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ if(ASAGI AND EASICUBE)
     set_target_properties (easicube PROPERTIES
         INSTALL_RPATH_USE_LINK_PATH TRUE
     )
+    target_link_libraries(easicube PUBLIC ${ASAGI_STATIC_LDFLAGS})
     install (TARGETS easicube)
 endif()
 


### PR DESCRIPTION
Fix this kind of error:
```
ulrich@heisenbug:/export/dump/ulrich/myLibs/easi/build$ /usr/bin/c++ -no-pie -Wl,-rpath -Wl,/opt/software/openmpi/buster/4.1.0_gcc-10.2.0/lib -Wl,--enable-new-dtags -pthread CMakeFiles/easicube.dir/tools/easicube.cpp.o -o easicube  -Wl,-rpath,/opt/software/openmpi/buster/4.1.0_gcc-10.2.0/lib: libeasi.a /export/dump/ulrich/SeisSol-GPU-build/lib/libyaml-cpp.a /usr/lib/gcc/x86_64-linux-gnu/8/libgomp.so /usr/lib/x86_64-linux-gnu/libpthread.so /export/dump/ulrich/SeisSol-GPU-build/lib/libhdf5_hl.a /export/dump/ulrich/SeisSol-GPU-build/lib/libhdf5.a /usr/lib/x86_64-linux-gnu/libz.so /usr/lib/x86_64-linux-gnu/libdl.so /export/dump/ulrich/SeisSol-GPU-build/lib/libasagi.a /usr/lib/x86_64-linux-gnu/libnuma.so /export/dump/ulrich/SeisSol-GPU-build/lib/libnetcdf.a -lm /opt/software/openmpi/buster/4.1.0_gcc-10.2.0/lib/libmpi_cxx.so /opt/software/openmpi/buster/4.1.0_gcc-10.2.0/lib/libmpi.so 
/usr/bin/ld: /export/dump/ulrich/SeisSol-GPU-build/lib/libnetcdf.a(libnetcdf4_la-nc4file.o): in function `hdf5free':
nc4file.c:(.text+0x1b): undefined reference to `H5free_memory'
/usr/bin/ld: /export/dump/ulrich/SeisSol-GPU-build/lib/libnetcdf.a(libnetcdf4_la-nc4file.o): in function `get_netcdf_type':
nc4file.c:(.text+0x72): undefined reference to `H5Tget_class'
/usr/bin/ld: nc4file.c:(.text+0x97): undefined reference to `H5Tis_variable_str'
/usr/bin/ld: nc4file.c:(.text+0xe5): undefined reference to `H5open'
/usr/bin/ld: nc4file.c:(.text+0xec): undefined reference to `H5T_NATIVE_SCHAR_g'
/usr/bin/ld: nc4file.c:(.text+0xfe): undefined reference to `H5Tequal'
/usr/bin/ld: nc4file.c:(.text+0x130): undefined reference to `H5open'
/usr/bin/ld: nc4file.c:(.text+0x137): undefined reference to `H5T_NATIVE_SHORT_g'
/usr/bin/ld: nc4file.c:(.text+0x149): undefined reference to `H5Tequal'
/usr/bin/ld: nc4file.c:(.text+0x17b): undefined reference to `H5open'
```