### PR TITLE
Enable lua by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(IMPALAJIT_BACKEND original CACHE STRING "Which backend to use")
 set(IMPALAJIT_BACKEND_OPTIONS original llvm)
 set_property(CACHE IMPALAJIT_BACKEND PROPERTY STRINGS ${IMPALAJIT_BACKEND_OPTIONS})
 
-option(LUA "Use Lua" OFF)
+option(LUA "Use Lua" ON)
 
 function(check_parameter parameter_name value options)
 


### PR DESCRIPTION
As a lot of scenarios in the examples repo require lua now, I'd like to turn lua on by default.
Yesterday, I ran into the same problem as in https://github.com/SeisSol/easi/issues/45