### PR TITLE
python wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(easi)
 cmake_minimum_required(VERSION 3.13)
 set(EASI_VERSION_MAJOR 1)
-set(EASI_VERSION_MINOR 2)
+set(EASI_VERSION_MINOR 3)
 set(EASI_VERSION_PATCH 0)
 
 add_compile_definitions(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ endif()
 
 if (PYTHON_BINDINGS)
     set(PYBIND11_VER 2.11.1)
+    set(PYBIND11_FINDPYTHON ON)
     find_package(pybind11 ${PYBIND11_VER} QUIET)
     if (NOT pybind11_FOUND)
          include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ set(EASI_VERSION_MAJOR 1)
 set(EASI_VERSION_MINOR 2)
 set(EASI_VERSION_PATCH 0)
 
+add_compile_definitions(
+    EASI_VERSION="${EASI_VERSION_MAJOR}.${EASI_VERSION_MINOR}.${EASI_VERSION_PATCH}"
+)
+
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
@@ -15,6 +19,7 @@ option(BUILD_SHARED_LIBS "compile as a shared library" OFF)
 option(TESTING "Compile tests" OFF)
 option(EASICUBE "Compile easicube" ON)
 option(IMPALAJIT "Use ImpalaJIT" ON)
+option(PYTHON_BINDINGS "Compile python bindings" OFF)
 set(IMPALAJIT_BACKEND original CACHE STRING "Which backend to use")
 set(IMPALAJIT_BACKEND_OPTIONS original llvm)
 set_property(CACHE IMPALAJIT_BACKEND PROPERTY STRINGS ${IMPALAJIT_BACKEND_OPTIONS})
@@ -55,6 +60,23 @@ if(ASAGI)
     find_package (HDF5 REQUIRED COMPONENTS C HL)
     pkg_check_modules (NETCDF REQUIRED IMPORTED_TARGET netcdf)
     pkg_check_modules (ASAGI REQUIRED IMPORTED_TARGET asagi)
+endif()
+
+if (PYTHON_BINDINGS)
+    set(PYBIND11_VER 2.11.1)
+    find_package(pybind11 ${PYBIND11_VER} QUIET)
+    if (NOT pybind11_FOUND)
+         include(FetchContent)
+         FetchContent_Declare(pybind11
+                            GIT_REPOSITORY https://github.com/pybind/pybind11.git
+                            GIT_TAG v${PYBIND11_VER})
+         FetchContent_MakeAvailable(pybind11)
+    endif ()
+
+    message(STATUS "Building Python bindings enabled")
+    add_subdirectory(python_bindings)
+    # position-independent code is required for linking a dynamic lib (e.g. pybind)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
 ### easi lib ###
@@ -203,6 +225,14 @@ if(EASICUBE)
     else()
         message(WARNING "easicube needs easi to be compiled with ASAGI. Since this is not the case, easicube will be skipped.")
     endif()
+endif()
+
+if (PYTHON_BINDINGS)
+   #easi_INSTALL_PYTHONDIR can be predefined, e.g. with spack to install the python module with the other python modules
+   set(INSTALL_DESTINATION "$<$<BOOL:${easi_INSTALL_PYTHONDIR}>:${easi_INSTALL_PYTHONDIR}/easi>${CONFIG_DESTINATION}/python_wrapper")
+   install(TARGETS easi_python
+           EXPORT easi_python
+           LIBRARY DESTINATION ${INSTALL_DESTINATION})
 endif()
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,6 +36,7 @@ The final parameter vector is, in this example, always 3-dimensional as it conta
 
   getting_started
   compiling_dependencies
+  python_bindings
   components
   maps
   filters

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -6,40 +6,40 @@ Alternatively to using easi directly via cpp code, easi can be used through pyth
 Installation
 ------------
 
-The python wrappers have to first be installed with the `-DPYTHON_BINDINGS=ON` cmake option.
-Note that ASAGI and ImpalaJIT have to be compiled with `cmake .. -DCMAKE_CXX_FLAGS="-fPIC"`.
-The easi python module can then be found by python when the path to the library (e.g. easi.cpython-310-x86_64-linux-gnu.so) is added to the $PYTHONPATH environment variable.
+The python wrappers have to first be installed with the ``-DPYTHON_BINDINGS=ON`` cmake option.
+Note that ASAGI and ImpalaJIT have to be compiled with ``cmake .. -DCMAKE_CXX_FLAGS="-fPIC"``.
+The easi python module can then be found by python when the path to the library (i.e. the path to e.g. easi.cpython-310-x86_64-linux-gnu.so) is added to the $PYTHONPATH environment variable.
 
-```bash
-export PYTHONPATH=your_build_folder/python_bindings:$PYTHONPATH
-```
+.. code-block:: bash
+
+    export PYTHONPATH=your_build_folder/python_bindings:$PYTHONPATH
 
 Use
 ---
 
 The module can then be used as follows:
 
-```python
-import numpy as np
-import easi
+.. code-block:: python
 
-coords = np.random.rand(10,3)
-region = np.random.randint(1,3, 10)
-print(easi.evaluate_model(coords, region, ["rho", "lambda"], "test.yaml"))
-```
+    import numpy as np
+    import easi
+
+    coords = np.random.rand(10,3)
+    region = np.random.randint(1,3, 10)
+    print(easi.evaluate_model(coords, region, ["rho", "lambda"], "test.yaml"))
 
 This will print the following dictionary, e.g. for https://github.com/SeisSol/easi/blob/master/examples/1_groups.yaml and regions [2 1 1 2 1 1 1 2 1 1]:
 
-```python
-{'rho': array([2700., 2600., 2600., 2700., 2600., 2600., 2600., 2700., 2600.,
-       2600.]), 'lambda': array([3.24038016e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
-       2.08000000e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
-       2.08000000e+10, 2.08000000e+10])}
-```
+.. code-block:: python
+
+    {'rho': array([2700., 2600., 2600., 2700., 2600., 2600., 2600., 2700., 2600.,
+           2600.]), 'lambda': array([3.24038016e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
+           2.08000000e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
+           2.08000000e+10, 2.08000000e+10])}
 
 Troubleshooting
 ---------------
 
-An error `libnetcdf.so.18: undefined symbol: H5Pset_dxpl_mpio` at `import easi` is probably associated with a module loaded above depending on a conflicting netcdf or hdf5 library (e.g. vtk).
+An error ``libnetcdf.so.18: undefined symbol: H5Pset_dxpl_mpio`` at ``import easi`` is probably associated with a module loaded above depending on a conflicting netcdf or hdf5 library (e.g. vtk).
 
-An error `ModuleNotFoundError: No module named 'easi'` may be cause by a $PYTHONPATH not pointing to the right folder, or a library compiled with the wrong python version (e.g. the library was compiled for the default python version and used with the Anaconda python).
+An error ``ModuleNotFoundError: No module named 'easi'`` may be cause by a $PYTHONPATH not pointing to the right folder, or a library compiled with the wrong python version (e.g. the library was compiled for the default python version and used with the Anaconda python, with different version number).

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -1,0 +1,45 @@
+Python wrapper
+===============
+
+Alternatively to using easi directly via cpp code, easi can be used through python wrappers.
+
+Installation
+------------
+
+The python wrappers have to first be installed with the `-DPYTHON_BINDINGS=ON` cmake option.
+Note that ASAGI and ImpalaJIT have to be compiled with `cmake .. -DCMAKE_CXX_FLAGS="-fPIC"`.
+The easi python module can then be found by python when the path to the library (e.g. easi.cpython-310-x86_64-linux-gnu.so) is added to the $PYTHONPATH environment variable.
+
+```bash
+export PYTHONPATH=your_build_folder/python_bindings:$PYTHONPATH
+```
+
+Use
+---
+
+The module can then be used as follows:
+
+```python
+import numpy as np
+import easi
+
+coords = np.random.rand(10,3)
+region = np.random.randint(1,3, 10)
+print(easi.evaluate_model(coords, region, ["rho", "lambda"], "test.yaml"))
+```
+
+This will print the following dictionary, e.g. for https://github.com/SeisSol/easi/blob/master/examples/1_groups.yaml and regions [2 1 1 2 1 1 1 2 1 1]:
+
+```python
+{'rho': array([2700., 2600., 2600., 2700., 2600., 2600., 2600., 2700., 2600.,
+       2600.]), 'lambda': array([3.24038016e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
+       2.08000000e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
+       2.08000000e+10, 2.08000000e+10])}
+```
+
+Troubleshooting
+---------------
+
+An error `libnetcdf.so.18: undefined symbol: H5Pset_dxpl_mpio` at `import easi` is probably associated with a module loaded above depending on a conflicting netcdf or hdf5 library (e.g. vtk).
+
+An error `ModuleNotFoundError: No module named 'easi'` may be cause by a $PYTHONPATH not pointing to the right folder, or a library compiled with the wrong python version (e.g. the library was compiled for the default python version and used with the Anaconda python).

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -1,0 +1,7 @@
+pybind11_add_module(easi_python easi_wrapper.cpp)
+set_target_properties(easi_python
+  PROPERTIES
+  LIBRARY_OUTPUT_NAME easi
+  VERSION ${EASI_VERSION_MAJOR}.${EASI_VERSION_MINOR}.${EASI_VERSION_PATCH}
+  EXPORT_NAME Python)
+target_link_libraries(easi_python PRIVATE easi)

--- a/python_bindings/README.md
+++ b/python_bindings/README.md
@@ -1,0 +1,33 @@
+# A python wrapper for easi
+
+Install with `-DPYTHON_BINDINGS=ON` cmake option.
+
+Add the library to your path:
+
+```bash
+export PYTHONPATH=your_build_folder>python_bindings:$PYTHONPATH
+```
+
+The module can then be used as follows:
+
+```python
+import numpy as np
+import easi
+
+coords = np.random.rand(10,3)
+region = np.random.randint(1,3, 10)
+print(easi.evaluate_model(coords, region, ["rho", "lambda"], "test.yaml"))
+```
+
+This will print the following dictionary, e.g. for https://github.com/SeisSol/easi/blob/master/examples/1_groups.yaml and regions [2 1 1 2 1 1 1 2 1 1]:
+
+```python
+{'rho': array([2700., 2600., 2600., 2700., 2600., 2600., 2600., 2700., 2600.,
+       2600.]), 'lambda': array([3.24038016e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
+       2.08000000e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
+       2.08000000e+10, 2.08000000e+10])}
+```
+
+# Troubleshooting
+
+an error `libnetcdf.so.18: undefined symbol: H5Pset_dxpl_mpio` at `import easi` is probably associated with a module loaded above depending on a conflicting netcdf or hdf5 library (e.g. vtk).

--- a/python_bindings/README.md
+++ b/python_bindings/README.md
@@ -1,33 +1,3 @@
 # A python wrapper for easi
 
-Install with `-DPYTHON_BINDINGS=ON` cmake option.
-
-Add the library to your path:
-
-```bash
-export PYTHONPATH=your_build_folder>python_bindings:$PYTHONPATH
-```
-
-The module can then be used as follows:
-
-```python
-import numpy as np
-import easi
-
-coords = np.random.rand(10,3)
-region = np.random.randint(1,3, 10)
-print(easi.evaluate_model(coords, region, ["rho", "lambda"], "test.yaml"))
-```
-
-This will print the following dictionary, e.g. for https://github.com/SeisSol/easi/blob/master/examples/1_groups.yaml and regions [2 1 1 2 1 1 1 2 1 1]:
-
-```python
-{'rho': array([2700., 2600., 2600., 2700., 2600., 2600., 2600., 2700., 2600.,
-       2600.]), 'lambda': array([3.24038016e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
-       2.08000000e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
-       2.08000000e+10, 2.08000000e+10])}
-```
-
-# Troubleshooting
-
-an error `libnetcdf.so.18: undefined symbol: H5Pset_dxpl_mpio` at `import easi` is probably associated with a module loaded above depending on a conflicting netcdf or hdf5 library (e.g. vtk).
+see https://easyinit.readthedocs.io/en/latest/python_bindings.html

--- a/python_bindings/easi_wrapper.cpp
+++ b/python_bindings/easi_wrapper.cpp
@@ -1,0 +1,105 @@
+#include <easi/Query.h>
+#include <easi/ResultAdapter.h>
+#include <easi/YAMLParser.h>
+#include <mpi.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#ifndef EASI_VERSION
+#define EASI_VERSION "0.0.0"
+#endif
+
+namespace py = pybind11;
+
+void initializeMPI() { MPI_Init(NULL, NULL); }
+
+void finalizeMPI() { MPI_Finalize(); }
+
+void version(py::module& m) { m.attr("__version__") = EASI_VERSION; }
+
+struct OutputStruc {
+    double parameter;
+};
+
+py::array_t<double> evaluate_model_one_parameter(py::array_t<double> coordinates,
+                                                 py::array_t<int> groups,
+                                                 const std::string parameter_name,
+                                                 const std::string& yaml_file) {
+    // Obtain buffer pointers
+    auto coords_buf = coordinates.request();
+    auto groups_buf = groups.request();
+
+    if (coords_buf.ndim != 2 || coords_buf.shape[1] != 3) {
+        throw std::runtime_error("Input array must be of shape (npoints, 3)");
+    }
+
+    // Access data pointers
+    double* coords_data = static_cast<double*>(coords_buf.ptr);
+    int* groups_data = static_cast<int*>(groups_buf.ptr);
+
+    int npoints = coords_buf.shape[0];
+
+    easi::Query query(npoints, 3);
+
+    for (int i = 0; i < npoints; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            query.x(i, j) = coords_data[i * 3 + j];
+        }
+        query.group(i) = groups_data[i];
+    }
+
+    easi::YAMLParser parser(3);
+    easi::Component* model_stress = parser.parse(yaml_file.c_str());
+
+    std::vector<OutputStruc> myOutputStruc(npoints);
+    easi::ArrayOfStructsAdapter<OutputStruc> adapter(myOutputStruc.data());
+    adapter.addBindingPoint(parameter_name.c_str(), &OutputStruc::parameter);
+
+    model_stress->evaluate(query, adapter);
+
+    delete model_stress;
+
+    // Create a new NumPy array to store the result
+    py::array_t<double> result_array(npoints);
+    auto result_buf = result_array.request();
+    double* result_data = static_cast<double*>(result_buf.ptr);
+
+    for (size_t i = 0; i < npoints; ++i) {
+        result_data[i] = myOutputStruc[i].parameter;
+    }
+    return result_array;
+}
+
+py::dict evaluate_model(py::array_t<double> coordinates, py::array_t<int> groups,
+                        const std::vector<std::string>& parameters, const std::string& yaml_file) {
+    // Create a Python dictionary to hold the results
+    py::dict result_dict;
+
+    for (const auto& parameter_name : parameters) {
+        result_dict[parameter_name.c_str()] =
+            evaluate_model_one_parameter(coordinates, groups, parameter_name, yaml_file);
+    }
+    return result_dict;
+}
+
+void initializeModule(py::module& m) {
+    // Call initializeMPI when the module is loaded
+    initializeMPI();
+    m.def("finalizeMPI", &finalizeMPI, "Finalize MPI");
+    m.def("evaluate_model", &evaluate_model, R"pbdoc(
+        Evaluate Easi model for given coordinates and parameters.
+
+        Parameters:
+        - coordinates (numpy.ndarray): Array of shape (npoints, 3) representing the coordinates.
+        - groups (numpy.ndarray): Array of integers representing the groups.
+        - parameters (List[str]): List of parameter names to evaluate.
+        - yaml_file (str): Path to the YAML file containing the Easi model.
+
+        Returns:
+        - Dict[str, numpy.ndarray]: Dictionary containing parameter names as keys and result arrays as values.
+    )pbdoc");
+    version(m);
+}
+
+PYBIND11_MODULE(easi, m) { initializeModule(m); }

--- a/tests/easitest.h
+++ b/tests/easitest.h
@@ -6,6 +6,7 @@
 #include <limits>
 #include <string>
 #include <vector>
+#include <array>
 
 struct ElasticMaterial {
     double lambda, mu, rho;


### PR DESCRIPTION
add python wrapper for easi.
Example of use:

```python
import numpy as np
import easi

coords = np.random.rand(10,3)
region = np.random.randint(1,3, 10)
print(easi.evaluate_model(coords, region, ["rho", "lambda"], "test.yaml"))
```
output with (https://github.com/SeisSol/easi/blob/master/examples/1_groups.yaml) and regions `[2 1 1 2 1 1 1 2 1 1]`:
```
{'rho': array([2700., 2600., 2600., 2700., 2600., 2600., 2600., 2700., 2600.,
       2600.]), 'lambda': array([3.24038016e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
       2.08000000e+10, 2.08000000e+10, 2.08000000e+10, 3.24038016e+10,
       2.08000000e+10, 2.08000000e+10])}
```

Will then be integrated to spack as:

https://github.com/Thomas-Ulrich/spack/tree/thomas/easi_pybind