### PR TITLE
fix documentation and add badge

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+   os: ubuntu-22.04
+   tools:
+      python: "3.11"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: doc/conf.py
@@ -15,6 +21,5 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
    install:
    - requirements: doc/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # easi
 
+[![Documentation Status](https://readthedocs.org/projects/easyinit/badge/?version=latest)](https://easyinit.readthedocs.io/en/latest/?badge=latest)
+
+
 easi is a library for the **E**asy **I**nitialization of models in three (or less or more) dimensional domains.
 The purpose of easi is to evaluate functions f : R^m -> R^n,
 which are described in a [YAML](http://yaml.org) configuration file.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
-sphinx==4.2.0
-sphinx_rtd_theme==1.0.0
+urllib3<2
+sphinx==5.3.0
+sphinx_rtd_theme==1.2.0


### PR DESCRIPTION
Here I just align the readthedoc config on the one of SeisSol.
This should fix the current issue which was:
```Error
Config validation error in build.os. Value build not found.```
I also add a badge showing the status of the build of the documentation.
