### PR TITLE
Consider Relative Paths To The Parent File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+build*/
+
+.vscode/
+
+
+# https://github.com/github/gitignore/blob/main/C%2B%2B.gitignore
+# (licensed under: CC0 1.0 Universal)
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ include(CMakePackageConfigHelpers)
 
 enable_language(CXX)
 
+set( CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH} )
+
 option(ASAGI "Enable support for ASAGI" ON)
 option(BUILD_SHARED_LIBS "compile as a shared library" OFF)
 
@@ -42,6 +44,8 @@ check_parameter("IMPALAJIT_BACKEND" "${IMPALAJIT_BACKEND}" "${IMPALAJIT_BACKEND_
 
 find_package(yaml-cpp 0.6 REQUIRED)
 find_package(OpenMP)
+
+find_package(FILESYSTEM REQUIRED)
 
 if(IMPALAJIT)
     if (IMPALAJIT_BACKEND STREQUAL llvm)
@@ -123,6 +127,9 @@ target_link_libraries(easi
         yaml-cpp
 )
 target_include_directories(easi PUBLIC ${YAML_CPP_INCLUDE_DIR})
+
+
+target_link_libraries(easi PRIVATE std::filesystem)
 
 if(${OpenMP_CXX_FOUND})
     target_link_libraries(easi PRIVATE OpenMP::OpenMP_CXX)

--- a/cmake/FindFILESYSTEM.cmake
+++ b/cmake/FindFILESYSTEM.cmake
@@ -1,0 +1,112 @@
+#  FILESYSTEM - filesystem component of the standard library
+#
+#  FILESYSTEM_FOUND       - system has std::filesystem
+#  FILESYSTEM_LIBRARIES   - libraries for std::filesystem
+#  std::filesystem        - imported target
+#
+#  NOTE: it is not an official cmake search file
+#  authors: Carsten Uphoff, Ravil Dorozhinskii
+#  email: uphoff@in.tum.de, ravil.dorozhinskii@tum.de 
+#
+
+
+include(FindPackageHandleStandardArgs)
+include(CheckCXXSourceRuns)
+include(CMakePushCheckState)
+
+cmake_push_check_state()
+
+set(_PARENT_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+set(CMAKE_CXX_STANDARD 17)
+
+
+set(_FILESYSTEM_TEST_RPOGRAM "
+#include <iostream>
+
+#ifdef EXPERIMENTAL_FS
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
+
+int main(int argc, char* argv[]) {
+    fs::path p{argv[0]};
+    std::cout << fs::canonical(p) << std::endl;
+    return 0;
+}")
+
+function(test_program filesystem_libraries use_experimental_fs is_ok)
+    cmake_push_check_state(RESET)
+    set(${is_ok} TRUE PARENT_SCOPE)
+    if (${use_experimental_fs})
+        set(CMAKE_REQUIRED_DEFINITIONS "-DEXPERIMENTAL_FS")
+        set(TEST_SUFFIX "EXPERIMENTAL")
+    else()
+        set(TEST_SUFFIX "NATIVE")
+    endif()
+
+    check_cxx_source_runs("${_FILESYSTEM_TEST_RPOGRAM}" _FILESYSTEM_${TEST_SUFFIX})
+
+    if (_FILESYSTEM_${TEST_SUFFIX})
+        # a compiler has a native support for std::filesystem
+        set(${filesystem_libraries} "" PARENT_SCOPE)
+    else()
+        set(CMAKE_REQUIRED_LIBRARIES "stdc++fs")
+        check_cxx_source_runs("${_FILESYSTEM_TEST_RPOGRAM}" _FILESYSTEM_STDCPPFS_${TEST_SUFFIX})
+
+        if(_FILESYSTEM_STDCPPFS_${TEST_SUFFIX})
+            set(${filesystem_libraries} "stdc++fs" PARENT_SCOPE)
+        else()
+            set(CMAKE_REQUIRED_LIBRARIES "c++fs")
+            check_cxx_source_runs("${_FILESYSTEM_TEST_RPOGRAM}" _FILESYSTEM_CPPFS_${TEST_SUFFIX})
+
+            if(_FILESYSTEM_CPPFS_${TEST_SUFFIX})
+                set(${filesystem_libraries} "c++fs" PARENT_SCOPE)
+            else()
+                set(${is_ok} FALSE PARENT_SCOPE)
+            endif()
+        endif()
+    endif()
+    cmake_pop_check_state()
+endfunction()
+
+set(FILESYSTEM_LIBRARIES "")
+set(IS_OK FALSE)
+test_program(FILESYSTEM_LIBRARIES FALSE IS_OK)
+
+IF (IS_OK)
+    set(IS_STD_FILESYSTEM_SUPPORT TRUE)
+else()
+    set(FILESYSTEM_LIBRARIES "")
+    set(USE_EXPERIMENTAL_FS TRUE)
+    test_program(FILESYSTEM_LIBRARIES TRUE IS_OK)
+
+    if (IS_OK)
+        set(IS_STD_FILESYSTEM_SUPPORT FALSE)
+    else()
+        # there is no way to compile a sample program with std::filesystem
+        message(FATAL_ERROR "C++ compiler does not support std[::experimental]::filesystem")
+    endif()
+endif()
+
+
+if (DEFINED FILESYSTEM_LIBRARIES)
+    add_library(std::filesystem INTERFACE IMPORTED)
+    set_property(TARGET std::filesystem APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_17)
+
+    if (FILESYSTEM_LIBRARIES)
+        set_property(TARGET std::filesystem APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${FILESYSTEM_LIBRARIES})
+    endif()
+
+    if (NOT IS_STD_FILESYSTEM_SUPPORT)
+        set_property(TARGET std::filesystem APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS EXPERIMENTAL_FS)
+    endif()
+endif()
+
+find_package_handle_standard_args(FILESYSTEM FILESYSTEM_LIBRARIES)
+
+mark_as_advanced(FILESYSTEM_LIBRARIES _PARENT_CMAKE_CXX_STANDARD)
+set(CMAKE_CXX_STANDARD ${_PARENT_CMAKE_CXX_STANDARD})
+cmake_pop_check_state()


### PR DESCRIPTION
This PR changes that include paths are considered relative to the parent (i.e. including) easi file, and not relative to the current execution directory.

Besides, we add a .gitignore .
