### PR TITLE
Switch off EASICUBE as default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(ASAGI "Enable support for ASAGI" ON)
 option(BUILD_SHARED_LIBS "compile as a shared library" OFF)
 
 option(TESTING "Compile tests" OFF)
-option(EASICUBE "Compile easicube" ON)
+option(EASICUBE "Compile easicube" OFF)
 option(IMPALAJIT "Use ImpalaJIT" ON)
 option(PYTHON_BINDINGS "Compile python bindings" OFF)
 set(IMPALAJIT_BACKEND original CACHE STRING "Which backend to use")


### PR DESCRIPTION
We don't really use EASICUBE that often, switching it off as default helps to successfully compile without extra work