### PR TITLE
Re-enable paths relative to the current directory (as second choice)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-project(easi)
 cmake_minimum_required(VERSION 3.13)
+
+project(easi)
 set(EASI_VERSION_MAJOR 1)
 set(EASI_VERSION_MINOR 3)
 set(EASI_VERSION_PATCH 0)

--- a/include/easi/YAMLParser.h
+++ b/include/easi/YAMLParser.h
@@ -3,12 +3,14 @@
 
 #include "parser/YAMLAbstractParser.h"
 
+#include <unordered_set>
 #include <yaml-cpp/yaml.h>
 
 #include <functional>
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace easi {
 
@@ -44,12 +46,15 @@ public:
     inline AsagiReader* asagiReader() override { return m_asagiReader; }
     inline std::string currentFileName() override { return m_currentFileName; }
 
+    std::vector<std::string> getFileNameList();
+
 private:
     std::set<std::string> m_in;
     std::unordered_map<std::string, std::function<CreateFunction>> m_creators;
     AsagiReader* m_asagiReader;
     bool m_externalAsagiReader;
     std::string m_currentFileName;
+    std::unordered_set<std::string> m_fileNames;
 };
 
 } // namespace easi

--- a/src/YAMLParser.cpp
+++ b/src/YAMLParser.cpp
@@ -92,7 +92,12 @@ Component* YAMLParser::parse(std::string const& fileName) {
                 return nextPath;
             }
         }();
-        m_currentFileName = loadFileName;
+        if (fs::exists(loadFileName)) {
+            m_currentFileName = loadFileName;
+        }
+        else {
+            m_currentFileName = fs::current_path() / nextPath;
+        }
         YAML::Node config = YAML::LoadFile(loadFileName);
         root = parse(config, m_in);
         m_currentFileName = lastFileName;

--- a/src/YAMLParser.cpp
+++ b/src/YAMLParser.cpp
@@ -14,6 +14,7 @@ class AsagiReader {};
 #endif
 
 #include <iostream>
+#include <vector>
 
 #ifdef EXPERIMENTAL_FS
 #include <experimental/filesystem>
@@ -93,11 +94,12 @@ Component* YAMLParser::parse(std::string const& fileName) {
             }
         }();
         if (fs::exists(loadFileName)) {
-            m_currentFileName = loadFileName;
+            m_currentFileName = fs::canonical(loadFileName);
         }
-        else {
-            m_currentFileName = fs::current_path() / nextPath;
+        else if (fs::exists(nextPath)) {
+            m_currentFileName = nextPath;
         }
+        m_fileNames.insert(m_currentFileName);
         YAML::Node config = YAML::LoadFile(loadFileName);
         root = parse(config, m_in);
         m_currentFileName = lastFileName;
@@ -125,6 +127,10 @@ Component* YAMLParser::parse(YAML::Node const& node, std::set<std::string> const
         throw YAML::Exception(node.Mark(), ss.str());
     }
     return component;
+}
+
+std::vector<std::string> YAMLParser::getFileNameList() {
+    return std::vector<std::string>(m_fileNames.begin(), m_fileNames.end());
 }
 
 } // namespace easi

--- a/src/parser/YAMLComponentParsers.cpp
+++ b/src/parser/YAMLComponentParsers.cpp
@@ -28,10 +28,10 @@ namespace {
             const auto filePath = fs::path(parser->currentFileName());
             const auto newPath = filePath.parent_path() / entryPath;
             if (fs::exists(newPath)) {
-                return newPath;
+                return fs::canonical(newPath);
             }
             else {
-                return fs::current_path() / filePath;
+                return filePath;
             }
         }
         else {

--- a/src/parser/YAMLComponentParsers.cpp
+++ b/src/parser/YAMLComponentParsers.cpp
@@ -26,7 +26,13 @@ namespace {
         if (entryPath.is_relative()) {
             // remove file
             const auto filePath = fs::path(parser->currentFileName());
-            return filePath.parent_path() / entryPath;
+            const auto newPath = filePath.parent_path() / entryPath;
+            if (fs::exists(newPath)) {
+                return newPath;
+            }
+            else {
+                return fs::current_path() / filePath;
+            }
         }
         else {
             return entryPath;


### PR DESCRIPTION
To match [#1156](https://github.com/SeisSol/SeisSol/pull/1156) :

* we still look for a path relative to the parent file first
* if that file isn't found, we default to the path relative to the current working directory instead
