### PR TITLE
Fix `std::filesystem` imported target export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,9 +117,9 @@ if(ASAGI)
 endif()
 
 add_library(easi ${EASI_SOURCES})
-target_compile_features(easi PUBLIC cxx_std_14)
+target_compile_features(easi PUBLIC cxx_std_17)
 set_target_properties(easi PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )
@@ -141,8 +141,11 @@ else()
   endif()
 endif()
 
-
-target_link_libraries(easi PRIVATE std::filesystem)
+# avoid linking to the imported std::filesystem target for now; to avoid its export
+target_link_libraries(easi PRIVATE ${FILESYSTEM_LIBRARIES})
+if (NOT IS_STD_FILESYSTEM_SUPPORT)
+    target_compile_definitions(easi PRIVATE EXPERIMENTAL_FS)
+endif()
 
 if(${OpenMP_CXX_FOUND})
     target_link_libraries(easi PRIVATE OpenMP::OpenMP_CXX)


### PR DESCRIPTION
A hotfix, so that `std::filesystem` isn't linked to as an imported target (and subsequently not not found by e.g. PUMgen). The solution now may be not too ideal (i.e. too verbose, too "old" CMake)—but given that we may be able to remove it pretty soon-ish anyways... Unless someone has a cleaner solution present; I'd let it stay at that.
Also, we now use C++17 for all of easi.
