### PR TITLE
Allow the direct specification of the input dimension names

### DIFF
--- a/include/easi/YAMLParser.h
+++ b/include/easi/YAMLParser.h
@@ -27,6 +27,8 @@ public:
 
     YAMLParser(unsigned dimDomain, AsagiReader* externalAsagiReader = nullptr,
                char firstVariable = 'x');
+    YAMLParser(const std::set<std::string>& variables,
+               AsagiReader* externalAsagiReader = nullptr);
     virtual ~YAMLParser();
 
     void registerType(std::string const& tag, std::function<CreateFunction> create);

--- a/src/YAMLParser.cpp
+++ b/src/YAMLParser.cpp
@@ -4,6 +4,7 @@
 #include "easi/component/OptimalStress.h"
 #include "easi/component/Special.h"
 #include "easi/parser/YAMLComponentParsers.h"
+#include <set>
 
 #ifdef EASI_USE_ASAGI
 #include "easi/util/AsagiReader.h"
@@ -28,13 +29,24 @@ namespace fs = std::experimental::filesystem;
 namespace fs = std::filesystem;
 #endif
 
+namespace {
+    std::set<std::string> makeVariables(std::size_t count, char first) {
+        std::set<std::string> variables;
+        for (std::size_t i = 0; i < count; ++i) {
+            variables.insert(std::string(1, first + i));
+        }
+        return variables;
+    }
+}
+
 namespace easi {
 
 YAMLParser::YAMLParser(unsigned dimDomain, AsagiReader* externalAsagiReader, char firstVariable)
-    : m_asagiReader(externalAsagiReader), m_externalAsagiReader(externalAsagiReader != nullptr) {
-    for (unsigned i = 0; i < dimDomain; ++i) {
-        m_in.insert(std::string(1, firstVariable + i));
-    }
+    : YAMLParser(makeVariables(dimDomain, firstVariable), externalAsagiReader) {
+}
+
+YAMLParser::YAMLParser(const std::set<std::string>& variables, AsagiReader* externalAsagiReader)
+    : m_in(variables), m_asagiReader(externalAsagiReader), m_externalAsagiReader(externalAsagiReader != nullptr) {
     registerType("!Switch", parse_Switch);
     registerType("!ConstantMap", parse_ConstantMap);
     registerType("!PolynomialMap", parse_PolynomialMap);


### PR DESCRIPTION
This PR allows the direct input of the input variable set (before, it was incremented from a start character up to the number of dimensions given). Thus, we can now also set something like `{"t", "x", "y", "z"}`. The set ordering is still in place.