### PR TITLE
Remove custom destructor for the Query class

### DIFF
--- a/include/easi/Query.h
+++ b/include/easi/Query.h
@@ -12,7 +12,6 @@ struct Query {
     Vector<unsigned> index;
 
     Query(unsigned numPoints, unsigned dimDomain, bool initIndices = true);
-    ~Query();
 
     inline unsigned numPoints() const { return x.rows(); }
     inline unsigned dimDomain() const { return x.cols(); }

--- a/src/Query.cpp
+++ b/src/Query.cpp
@@ -11,8 +11,6 @@ Query::Query(unsigned numPoints, unsigned dimDomain, bool initIndices)
     }
 }
 
-Query::~Query() { clear(); }
-
 Query Query::shallowCopy() {
     Query copy = *this;
     return copy;


### PR DESCRIPTION
Causes issues with the `shallowCopy` method—and it can probably be removed like that, as the `Matrix`/`Vector` objects should clear up after themselves.

Draft until it's confirmed to be useful.
