### PR TITLE
Add an implicit `EvalModel` wrapper in case of a true composite map, when given as input for a `LayeredModel`

### DIFF
--- a/include/easi/component/Composite.h
+++ b/include/easi/component/Composite.h
@@ -36,6 +36,8 @@ public:
 
     virtual std::set<std::string> suppliedParameters();
 
+    std::size_t componentCount() { return m_components.size(); }
+
 protected:
     virtual Matrix<double> map(Matrix<double>& x) = 0;
 

--- a/src/parser/YAMLComponentParsers.cpp
+++ b/src/parser/YAMLComponentParsers.cpp
@@ -309,6 +309,18 @@ Component* create_LayeredModel(YAML::Node const& node, std::set<std::string> con
     LayeredModelBuilder::Parameters parameters =
         node["parameters"].as<LayeredModelBuilder::Parameters>();
 
+    if (map->componentCount() > 0) {
+        // Add another wrapper around the map---as the components would only stack otherwise
+        // (thus causing bugs)
+
+        auto* mapWrapper = new EvalModel();
+        // NOTE: suppliedParameters yields the actual output variables of a Composite with sub Components
+        // (out only contains the pre-post-component-application parameters)
+        mapWrapper->setModel(map->in(), map->suppliedParameters(), map);
+
+        map = mapWrapper;
+    }
+
     builder.setMap(map);
     builder.setInterpolationType(interpolation);
     builder.setNodes(nodes);


### PR DESCRIPTION
The `LayeredModel` (due to it being a builder) would only append components to the inner composite given by the `map` parameter. In that case, to prevent any problems, we add an additional wrapper to fix the problem.

(feel free to object—if it goes against any easi philosophy present; it might break models which hinge on the `map` components being published instead of consumed by the `LayeredModel`—if those exist)

Fix #28 
