### PR TITLE
update pybind11 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,24 +59,45 @@ if(ASAGI)
     endif()
 endif()
 
-if (PYTHON_BINDINGS)
-    set(PYBIND11_VER 2.11.1)
+
+if(PYTHON_BINDINGS)
+    set(PYBIND11_VER 2.13.6)
+    # pybind11 is the first supporting compiling for NumPy 2
+    set(PYBIND11_VER_MIN 2.12.0)
     set(PYBIND11_FINDPYTHON ON)
-    find_package(pybind11 ${PYBIND11_VER} QUIET)
-    if (NOT pybind11_FOUND)
-         include(FetchContent)
-         FetchContent_Declare(pybind11
-                            GIT_REPOSITORY https://github.com/pybind/pybind11.git
-                            GIT_TAG v${PYBIND11_VER})
-         FetchContent_MakeAvailable(pybind11)
-    endif ()
+
+    set(NEED_FETCH FALSE)
+
+    find_package(pybind11 QUIET)
+
+    if(NOT pybind11_FOUND)
+        set(NEED_FETCH TRUE)
+    elseif(pybind11_VERSION VERSION_LESS PYBIND11_VER_MIN)
+        set(NEED_FETCH TRUE)
+        message(STATUS "Found pybind11 ${pybind11_VERSION} (in ${pybind11_DIR}) but need ${PYBIND11_VER_MIN}, will fetch newer version")
+    endif()
+
+    if(NEED_FETCH)
+        include(FetchContent)
+        FetchContent_Declare(pybind11
+            GIT_REPOSITORY https://github.com/pybind/pybind11.git
+            GIT_TAG v${PYBIND11_VER}
+        )
+        FetchContent_Populate(pybind11)
+
+        # Manually add the downloaded pybind11 to search path
+        list(PREPEND CMAKE_PREFIX_PATH "${pybind11_SOURCE_DIR}/cmake")
+    endif()
+
+    # Now, find_package again, cleanly
+    find_package(pybind11 REQUIRED)
 
     message(STATUS "Building Python bindings enabled")
     add_subdirectory(python_bindings)
     # position-independent code is required for linking a dynamic lib (e.g. pybind)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
+
 
 ### easi lib ###
 


### PR DESCRIPTION
fixes #78

```
di73yeq4@login04:/hppfs/scratch/0A/di73yeq4/2024-12-05_Mw7_California_Earthquak_nc75095651Solucion_strike_98_200m_o5_casc16_1km> python test.py 
/hppfs/work/pn49ha/di73yeq4/user_spack23.1/linux-sles15-skylake_avx512/easi/pbv-intel-2023.1.0-booysj2/lib/python3.10/site-packages/easilib64/cmake/easi/python_wrapper/easi.cpython-310-x86_64-linux-gnu.so
(24, 8)
{'rho': array([2574.04, 3375.4 ]), 'mu': array([2.57033338e+10, 6.75340885e+10]), 'lambda': array([3.31065303e+10, 8.52995376e+10])}
```

Note that previously if CMake was finding a version, which was  too old, the fetch new version through github was raising:
```
CMake Error: add_library cannot create ALIAS target "pybind11::pybind11_headers" because another target with the same name already exists.
```
So I had to update more the CMakeList.txt

and this is about 2.12 being the first release compatible with np2
https://github.com/pybind/pybind11/releases/tag/v2.12.0